### PR TITLE
Fix newsletter nav button overlapping the carousel

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -27,13 +27,13 @@
                 {% include nav/contribute.html %}
               </div>
             </div>
+            {% if site.newsletter_subscribe_url %}
+            <a class="item" href="{{ site.newsletter_subscribe_url }}" target="_blank"><b>NEWSLETTER</b></a>
+            {% endif %}
           </div>
         </div>
 <!--          <a href="https://forms.gle/9yAv3AFjjkvXKrf77" target = "_blank" ><button class="ui green big button">Add Entry</button></a>
 COMMENT OUT THIS UI ELEMENT AS IT SEEMS NO LONGER SUPPORTED !-->
-          {% if site.newsletter_subscribe_url %}
-          <a href="{{ site.newsletter_subscribe_url }}" target="_blank"><button class="ui blue big button">Monthly Newsletter</button></a>
-          {% endif %}
       </div>
 
       <div class="tablet only row"> <!-- Layout for tablets only -->

--- a/_includes/nav/contribute.html
+++ b/_includes/nav/contribute.html
@@ -6,3 +6,6 @@
 <a class="item" target="_blank" href="https://github.com/DIYbiosphere/sphere"><i class="fab fa-github fa-fw icon"></i>Github (repo)</a>
 <a class="item" href="/docs/"><i class="far fa-book fa-fw icon"></i>Learn More (docs)</a>
 <a class="item" href="/about/support-us"><i class="far fa-thumbs-up fa-fw icon"></i>Support Us</a>
+{% if site.newsletter_subscribe_url %}
+<a class="item" href="{{ site.newsletter_subscribe_url }}" target="_blank"><i class="far fa-newspaper fa-fw icon"></i>Monthly Newsletter</a>
+{% endif %}


### PR DESCRIPTION
Fixes a bug reported after PR #406 merged: the "Monthly Newsletter" button was floating outside the actual Semantic UI menu bar (sibling after it closes, not an item inside it), so it broke out of normal flow and overlapped the top of the homepage carousel, cutting off slide text.

Screenshot of the bug: the button sits over the carousel's top-left corner instead of in its own nav row.

**Fix:** moved it into the `right menu` as a real item, matching the existing `ABOUT`/`CONTRIBUTE` pattern (same reason the near-identical old "Add Entry" button next to it had already been disabled - "no longer supported" - it had the same structural problem). Also added it to `nav/contribute.html`, shared by the tablet/mobile hamburger menu, so smaller screens get it too (previously only the desktop nav row had it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)