### PR TITLE
Draft: DIYbio Monthly, Issue #1

### DIFF
--- a/_posts/2026-08-12-diybio-monthly-newsletter-issue-1.md
+++ b/_posts/2026-08-12-diybio-monthly-newsletter-issue-1.md
@@ -1,0 +1,40 @@
+---
+title: "DIYbio Monthly, Issue #1: We're Back"
+subtitle: A relaunch, a new $1M community lab project at MIT, and a big new resource for founders
+date: 2026-08-12
+tags:
+  - newsletter
+---
+
+It's been a while. DIYbio.org used to run weekly community roundups on the old blog — [News Round-up](https://diybio.org/2012/01/16/diybio-news-round-up/), [Weekly News](https://diybio.org/2014/07/08/weekly-news/), event calendars — going back to 2009, and even a physical [postcard micro-newsletter](/projects/postcards/) for a couple of volumes in 2012. It's been dormant for a long time. We're bringing it back, monthly, curated with the help of AI and reviewed by a human before anything goes out.
+
+Here's what's new.
+
+## MIT's building a "cloud laboratory for learning" — and it's a big deal
+
+MIT Media Lab was awarded a $1M grant from the Massachusetts Life Sciences Center to build a platform that lets anyone with an internet connection remotely run real biology, AI, and robotics experiments. It's led by David Kong, Director of the Media Lab's [Community Biotechnology Initiative](https://www.media.mit.edu/groups/community-bio/overview/) — the same group behind the [Global Community BioSummit](/events/globalcommunitybiosummit/). Not built yet, but worth watching closely: this is exactly the kind of "lower the barrier to entry" project this community has been chasing since 2008.
+
+[Full entry, with the grant announcement and background &rarr;](/labs/mitcloudlab/)
+
+## New resource: a real map of US biotech incubators & accelerators
+
+If you're a founder trying to figure out where to get wet-lab space, seed funding, or corporate mentorship, we just added 19 of the major US options to the directory — organized by what they actually offer:
+
+- **Turnkey wet-lab space**: LabCentral, BioLabs, MBC BioLabs, Alexandria LaunchLabs, SmartLabs
+- **Corporate/strategic programs**: JLABS (Johnson & Johnson), Bayer Co.Lab
+- **VC-backed accelerators**: Y Combinator, a16z Speedrun, SOSV (formerly IndieBio)
+- **University & regional centers**: Bakar BioLabs, QB3 Garage, StartX Med, KU Innovation Park, BioGenerator, Missouri Innovation Center, Kansas Bioscience Park, Sid Martin Biotechnology Incubator, SUNY Downstate Biotechnology Incubator, BioBAT
+
+[Browse the full Incubators collection &rarr;](/browse?q=&idx=diybiosphere&p=0&dFR%5Bcollection%5D%5B0%5D=incubators)
+
+## Directory clean-up
+
+A batch of overdue fixes to the labs/groups directory: a few entries that had drifted out of date got corrected (addresses, hosting organizations, active status), a couple of duplicate/stub entries got merged into their fuller counterparts, and the homepage map now focuses on community labs specifically rather than blending in every collection type. Small stuff, but it adds up — if you spot something wrong with your own lab or group's listing, [it's a quick GitHub edit](/docs/tutorials/edit-entry/) to fix.
+
+## Get involved
+
+- **Add or update an entry**: [GitHub tutorial](/docs/tutorials/add-entry/) — no coding experience needed, just a GitHub account.
+- **Something we should cover next month?** Email [contact@diybio.org](mailto:contact@diybio.org).
+- **Know someone who'd want this in their inbox?** Forward this, or point them to [the subscribe page](https://buttondown.com/diybio-news).
+
+See you next month.


### PR DESCRIPTION
First draft of the relaunched monthly newsletter. **Please review before merging** — merging is what makes this live and (once Buttondown's RSS import picks it up) sends it to subscribers.

**Covers:**
- MIT's Cloud Laboratory for Learning (the planned $1M MLSC-funded project, added to the directory earlier this week)
- The 19 new biotech incubators/accelerators added to the directory, grouped by type
- A short note on the recent directory cleanup (JOGL, DIYbio Melbourne, DIYbio Toronto, Hacklab TO, Ottawa Bio Science, homepage map now scoped to labs)
- Links back to the historical "News Round-up"/"Weekly News" posts on diybio.org for continuity

All links (internal and external) verified live before this PR was opened. Netlify should generate a deploy preview on this PR — that's the best way to see exactly how it'll render before deciding to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)