### PR TITLE
Fix RSS feed to include full post content for Buttondown

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -3,7 +3,7 @@ layout:
 ---
 
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
@@ -15,7 +15,8 @@ layout:
     {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
+        <description>{{ post.content | strip_html | truncatewords: 50 | xml_escape }}</description>
+        <content:encoded><![CDATA[{{ post.content }}]]></content:encoded>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>


### PR DESCRIPTION
The Buttondown draft created from Issue #1 came through with a generic-looking body (just a bare link, no actual article text) — confirmed via the API that Buttondown's \`content\` template variable pulls from RSS's \`content:encoded\` field specifically, which our feed didn't have (only plain \`description\`).

**Fix:** added \`xmlns:content\` + a \`content:encoded\`/CDATA element carrying the full post HTML. Also tightened \`description\` to an actual short excerpt (\`strip_html\` + \`truncatewords: 50\`) instead of dumping the whole raw post into it, which is more correct per RSS convention and avoids near-duplicating full content across both fields.

Verified via a standalone Liquid render test (mock post data) before pushing — \`content:encoded\` renders correctly with the full CDATA-wrapped content.

**After merging**, Issue #1's existing Buttondown draft won't automatically pick up the fix (it was already created) — may need to delete and let it re-import, or manually patch that one draft. Future issues should come through correctly from the start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)