### PR TITLE
Fix duplicated opening paragraph in newsletter drafts

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -15,7 +15,7 @@ layout:
     {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | strip_html | truncatewords: 50 | xml_escape }}</description>
+        <description>{% if post.subtitle %}{{ post.subtitle | xml_escape }}{% else %}{{ post.content | strip_html | truncatewords: 50 | xml_escape }}{% endif %}</description>
         <content:encoded><![CDATA[{{ post.content }}]]></content:encoded>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>


### PR DESCRIPTION
Follow-up to #412. That fix added \`content:encoded\` so Buttondown drafts get full content — but Buttondown's default template shows both \`description\` (as a preview blurb) and \`content:encoded\` (full body), and \`description\` was a truncated copy of the post's own opening paragraph. Result: the opening paragraph appeared twice in the actual draft.

**Fix:** use the post's \`subtitle\` field for \`description\` when present (distinct text, no overlap with the body), falling back to the old truncated-content behavior only for posts without a subtitle. Verified both branches via a Liquid render test before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)