### PR TITLE
Add newsletter archive page (/newsletter/)

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -27,9 +27,7 @@
                 {% include nav/contribute.html %}
               </div>
             </div>
-            {% if site.newsletter_subscribe_url %}
-            <a class="item" href="{{ site.newsletter_subscribe_url }}" target="_blank"><b>NEWSLETTER</b></a>
-            {% endif %}
+            <a class="item" href="/newsletter/"><b>NEWSLETTER</b></a>
           </div>
         </div>
 <!--          <a href="https://forms.gle/9yAv3AFjjkvXKrf77" target = "_blank" ><button class="ui green big button">Add Entry</button></a>

--- a/_includes/nav/contribute.html
+++ b/_includes/nav/contribute.html
@@ -6,6 +6,4 @@
 <a class="item" target="_blank" href="https://github.com/DIYbiosphere/sphere"><i class="fab fa-github fa-fw icon"></i>Github (repo)</a>
 <a class="item" href="/docs/"><i class="far fa-book fa-fw icon"></i>Learn More (docs)</a>
 <a class="item" href="/about/support-us"><i class="far fa-thumbs-up fa-fw icon"></i>Support Us</a>
-{% if site.newsletter_subscribe_url %}
-<a class="item" href="{{ site.newsletter_subscribe_url }}" target="_blank"><i class="far fa-newspaper fa-fw icon"></i>Monthly Newsletter</a>
-{% endif %}
+<a class="item" href="/newsletter/"><i class="far fa-newspaper fa-fw icon"></i>Monthly Newsletter</a>

--- a/_includes/newsletter-signup.html
+++ b/_includes/newsletter-signup.html
@@ -1,0 +1,19 @@
+<div class="row xo margin top sixfold">
+  <div class="ui container center aligned grid">
+    <div class="ui text container">
+      <h2 class="ui center aligned header">Get the Monthly Newsletter</h2>
+      <p>Community lab updates, events, and news from around the DIYbio world &mdash; once a month, no spam.</p>
+      <form action="https://buttondown.com/api/emails/embed-subscribe/diybio-news" method="post" class="embeddable-buttondown-form">
+        <label for="bd-email" style="position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0,0,0,0);">Enter your email</label>
+        <div class="ui action input">
+          <input type="email" name="email" id="bd-email" placeholder="you@example.com" required>
+          <input type="hidden" value="1" name="embed">
+          <button class="ui blue button" type="submit">Subscribe</button>
+        </div>
+      </form>
+      <p class="ui mini grey text" style="margin-top: 0.5em;">
+        <a href="https://buttondown.com/refer/diybio-news" target="_blank">Powered by Buttondown.</a>
+      </p>
+    </div>
+  </div>
+</div>

--- a/index.html
+++ b/index.html
@@ -276,25 +276,7 @@ layout: landing
     </div>
   </div>
 
-  <div class="row xo margin top sixfold">
-    <div class="ui container center aligned grid">
-      <div class="ui text container">
-        <h2 class="ui center aligned header">Get the Monthly Newsletter</h2>
-        <p>Community lab updates, events, and news from around the DIYbio world &mdash; once a month, no spam.</p>
-        <form action="https://buttondown.com/api/emails/embed-subscribe/diybio-news" method="post" class="embeddable-buttondown-form">
-          <label for="bd-email-home" style="position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0,0,0,0);">Enter your email</label>
-          <div class="ui action input">
-            <input type="email" name="email" id="bd-email-home" placeholder="you@example.com" required>
-            <input type="hidden" value="1" name="embed">
-            <button class="ui blue button" type="submit">Subscribe</button>
-          </div>
-        </form>
-        <p class="ui mini grey text" style="margin-top: 0.5em;">
-          <a href="https://buttondown.com/refer/diybio-news" target="_blank">Powered by Buttondown.</a>
-        </p>
-      </div>
-    </div>
-  </div>
+  {% include newsletter-signup.html %}
 
   <div class="row xo margin top sixfold">
     <div class="ui container center aligned grid">

--- a/newsletter.html
+++ b/newsletter.html
@@ -1,0 +1,26 @@
+---
+title: Newsletter
+subtitle: "DIYbio Monthly — community lab updates, events, and news, once a month"
+layout: page
+---
+
+{% include newsletter-signup.html %}
+
+<div class="ui container" style="margin-top: 2em;">
+  {% assign issues = site.posts | sort: 'date' | reverse %}
+  {% if issues.size == 0 %}
+  <p class="ui center aligned grey text">No issues yet &mdash; check back soon.</p>
+  {% else %}
+  <div class="ui relaxed divided list">
+    {% for issue in issues %}
+    <div class="item" style="padding: 1.5em 0;">
+      <div class="content">
+        <a class="header" href="{{ issue.url }}">{{ issue.title }}</a>
+        <div class="ui sub header xo margin top" style="margin-top: 0.3em; font-weight: normal; color: rgba(0,0,0,0.6);">{{ issue.date | date: "%B %-d, %Y" }}</div>
+        {% if issue.subtitle %}<p style="margin-top: 0.5em;">{{ issue.subtitle }}</p>{% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+  {% endif %}
+</div>


### PR DESCRIPTION
Fills the gap noted earlier: nothing on sphere.diybio.org linked to past newsletter issues even though each one lives here permanently as a real post.

**New page:** \`/newsletter/\` — lists all issues from \`site.posts\` (title, date, subtitle, link), grows automatically as new issues publish, no manual list to maintain. Includes the same subscribe form as the homepage.

**Nav:** "NEWSLETTER" (desktop + tablet/mobile hamburger) now points here instead of straight to the Buttondown subscribe page, so people can read past issues and subscribe from the same spot.

**Also:** extracted the subscribe form into \`_includes/newsletter-signup.html\` since it's now used in two places (homepage + this new page) instead of duplicated markup.

Doesn't replace Buttondown's own Archives page (buttondown.com/diybio-news/archive) — that still works fine on its own. This is a self-hosted second copy, mainly for ownership/SEO reasons (content on our own domain vs. a third-party vendor's).

Verified the sort/loop/empty-state logic via a standalone Liquid render test before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)