### PR TITLE
Box the newsletter signup CTA with a tinted background

### DIFF
--- a/_includes/newsletter-signup.html
+++ b/_includes/newsletter-signup.html
@@ -1,19 +1,21 @@
 <div class="row xo margin top sixfold">
-  <div class="ui container center aligned grid">
-    <div class="ui text container">
-      <h2 class="ui center aligned header">Get the Monthly Newsletter</h2>
-      <p>Community lab updates, events, and news from around the DIYbio world &mdash; once a month, no spam.</p>
-      <form action="https://buttondown.com/api/emails/embed-subscribe/diybio-news" method="post" class="embeddable-buttondown-form">
-        <label for="bd-email" style="position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0,0,0,0);">Enter your email</label>
-        <div class="ui action input">
-          <input type="email" name="email" id="bd-email" placeholder="you@example.com" required>
-          <input type="hidden" value="1" name="embed">
-          <button class="ui blue button" type="submit">Subscribe</button>
-        </div>
-      </form>
-      <p class="ui mini grey text" style="margin-top: 0.5em;">
-        <a href="https://buttondown.com/refer/diybio-news" target="_blank">Powered by Buttondown.</a>
-      </p>
+  <div class="ui container">
+    <div class="ui segment center aligned" style="background-color: #DFF0FF; border: none; box-shadow: none; border-radius: 8px; padding: 2.5em 2em;">
+      <div class="ui text container">
+        <h2 class="ui center aligned header">Get the Monthly Newsletter</h2>
+        <p>Community lab updates, events, and news from around the DIYbio world &mdash; once a month, no spam.</p>
+        <form action="https://buttondown.com/api/emails/embed-subscribe/diybio-news" method="post" class="embeddable-buttondown-form">
+          <label for="bd-email" style="position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0,0,0,0);">Enter your email</label>
+          <div class="ui action input">
+            <input type="email" name="email" id="bd-email" placeholder="you@example.com" required>
+            <input type="hidden" value="1" name="embed">
+            <button class="ui blue button" type="submit">Subscribe</button>
+          </div>
+        </form>
+        <p class="ui mini grey text" style="margin-top: 0.5em;">
+          <a href="https://buttondown.com/refer/diybio-news" target="_blank">Powered by Buttondown.</a>
+        </p>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
User feedback on /newsletter/: the page jumped left-aligned (title, issue list) -> center-aligned (CTA) -> left-aligned again, reading as visually inconsistent rather than intentional.

**Fix:** wrapped the signup CTA in a segment with the theme's existing \`@blueBackground\` tint (\`#DFF0FF\`, already defined in \`site.variables\` — reused rather than inventing a new color) and rounded corners, so it reads as a deliberate callout module. Left the rest of the page's alignment as-is (title/subtitle and issue list stay left, matching the rest of the site's content pages) — the boxing is what resolves the inconsistency, not changing everything to match.

Shared include, so this also updates the homepage's signup section the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)